### PR TITLE
Add optional configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,38 @@ Write shortcuts with an existing icon file:
 > `wineshortcut.py file.exe -da -i /path/to/icon_file.png`
 
 Just print contents and do not extract icon:
+
 > `wineshortcut.py file.exe -p -s`
+
+Write shortcut with custom wine prefix:
+
+> `wineshortcut.py -w $HOME/.wine `
+
+or with the quotation marks if necessary:
+
+> `wineshortcut.py -w "$HOME/.wine" `
+
+### Configuration file
+
+With a configuration file named `wineshortcut.json`, one can easily create shortcuts with predefined preferences, without typing or copying the full arguments again and again.
+It includes all command line switches described above. They are renamed with the following rules:
+
+- The prefix `--` is removed
+- All `-` are replaced by `_`
+
+For example, switch `to-desktop` is named `to_desktop` in the configuration file.
+
+#### An example
+
+With an example configuration file `wineshortcut.json`:
+
+```json
+{
+        "wine_prefix": "$HOME/.wine",
+        "to_desktop": true,
+        "to_appmenu": true
+}
+```
+
+The command `./wineshortcut.py ~/example.exe` is equivalent to `./wineshortcut.py ~/example.exe -d -w "$HOME/.wine"`.
+


### PR DESCRIPTION
Hello, I've added a configuration file `wineshortcut.json` for this script, which could provide predefined command line options.
Options in config file will be overridden if the same option is provided in the command line parameters. And one can run this script without the configuration file.
I also renamed the switch `--print-output` to `--dry-run`, which is a more suitable name.
Detailed descriptions can be found in the commit message and the updated `README.md` file.